### PR TITLE
fix: Add sed to Alpine Linux environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       uses: xu-cheng/texlive-action/full@v1
       with:
         run: |
-          apk add make
+          apk add make sed
           make document
 
     - name: List directory


### PR DESCRIPTION
* Update sed to a recent version that will be compatible with sed commands used in arXiv Make target.
* c.f. https://github.com/matthewfeickert-papers/chep-2023-proceedings-bayesian-pyhf/pull/8